### PR TITLE
#94 The SetUrlFile method has been adjusted for Delphi 7.

### DIFF
--- a/src_dx7/uOpenOffice.pas
+++ b/src_dx7/uOpenOffice.pas
@@ -93,7 +93,7 @@ procedure TOpenOffice.SetURlFile(const Value: string);
 begin
   FURlFile := Value;
 
-  if (trim(FURlFile) <> '') or (FURlFile = NewFile[integer(TpCalc)] )
+  if (trim(FURlFile) = '') or (FURlFile = NewFile[integer(TpCalc)] )
                            or (FURlFile = NewFile[integer(TpWriter)]) then
     exit;
 


### PR DESCRIPTION
The problem is in this section: if (trim(FURlFile) <> ''). The comparison should be equal, not different.