### PR TITLE
Fix DataSetToSheet field index mismatch and add overload for TDataSet on Delphi 7

### DIFF
--- a/src_dx7/uOpenOffice_calc.pas
+++ b/src_dx7/uOpenOffice_calc.pas
@@ -36,18 +36,18 @@ type
 
   TBoderSheet = set of TBorder;
 
-  { STANDARD : é o alinhamento padrão tanto para números como para textos, sendo a esqueda para as strings e a direita para os números;
-    LEFT : o conteúdo é alinhado no lado esquerdo da célula;
-    CENTER : o conteúdo é alinhado no centro da célula;
-    RIGHT : o conteúdo é alinhado no lado direito da célula;
-    BLOCK : o conteúdo é alinhando em relação ao comprimento da célula;
-    REPEAT : o conteúdo é repetido dentro da célula para preenchê-la. }
+  { STANDARD : Ã© o alinhamento padrÃ£o tanto para nÃºmeros como para textos, sendo a esqueda para as strings e a direita para os nÃºmeros;
+    LEFT : o conteÃºdo Ã© alinhado no lado esquerdo da cÃ©lula;
+    CENTER : o conteÃºdo Ã© alinhado no centro da cÃ©lula;
+    RIGHT : o conteÃºdo Ã© alinhado no lado direito da cÃ©lula;
+    BLOCK : o conteÃºdo Ã© alinhando em relaÃ§Ã£o ao comprimento da cÃ©lula;
+    REPEAT : o conteÃºdo Ã© repetido dentro da cÃ©lula para preenchÃª-la. }
   THoriJustify = (fthSTANDARD, fthLEFT, fthCENTER, fthRIGHT, fthBLOCK,
     fthREPEAT);
-  { STANDARD : é o valor usado como padrão;
-    TOP : o conteúdo da célula é alinhado pelo topo;
-    CENTER : o conteúdo da célula é alinhado pelo centro;
-    BOTTOM : o conteúdo da célula é alinhado pela base. }
+  { STANDARD : Ã© o valor usado como padrÃ£o;
+    TOP : o conteÃºdo da cÃ©lula Ã© alinhado pelo topo;
+    CENTER : o conteÃºdo da cÃ©lula Ã© alinhado pelo centro;
+    BOTTOM : o conteÃºdo da cÃ©lula Ã© alinhado pela base. }
   TVertJustify = (ftvSTANDARD, ftvTOP, ftvCENTER, ftvBOTTOM);
 
   TFields = record
@@ -92,7 +92,8 @@ type
     function setFormula(aCellNumber: integer; aCollName: string; aFormula: string): TOpenOffice_calc;
     function SetValue(aCellNumber: integer; aCollName: string; aValue: variant; TypeValue: TTypeValue = ftString; Wrapped: boolean = false): TOpenOffice_calc;
     function GetValue(aCellNumber: integer; aCollName: String): TOpenOffice_calc;
-    procedure DataSetToSheet(const aCds : TClientDataSet);
+    procedure DataSetToSheet(const aCds : TClientDataSet); overload;
+    procedure DataSetToSheet(const aCds : TDataSet); overload;
     procedure addChart(aSettingsChart: TSettingsChart);
     function setBorder(borderPosition: TBoderSheet; opColor: TOpenColor; RemoveBorder: boolean = false) : TOpenOffice_calc;
     function changeFont(aNameFont: string; aHeight: Integer): TOpenOffice_calc;
@@ -177,15 +178,13 @@ var
   LCID: LangID;
   Language: array [0 .. 100] of char;
 begin
-
   LCID := GetSystemDefaultLangID;
 
   if Trim(SheetName) = '' then
   begin
-
     VerLanguageName(LCID, Language, 100);
 
-    if pos('Português', String(Language)) > 0 then
+    if pos('PortuguÃªs', String(Language)) > 0 then
       SheetName := DefaultNewSheetNamePT
     else
       SheetName := DefaultNewSheetNameEn;
@@ -237,33 +236,72 @@ begin
 end;
 
 procedure TOpenOffice_calc.DataSetToSheet(const aCds: TClientDataSet);
-var idx,idxFields : integer;
+var 
+	idx, idxFields : integer;
     lTypeVl : TTypeValue;
 begin
   aCds.DisableControls;
   try
     //Create header
     for idx := 0 to pred(aCds.Fields.Count) do
-      SetValue(0,FFields.arrFields[idx],aCds.Fields[idx].DisplayName)
+      SetValue(0, FFields.arrFields[idx], aCds.Fields[idx].DisplayName)
       .setBold(true)
       .setBorder([bAll], opBlack)
       .changeFont('Liberation Sans',11)
-      .setColor(opWhite,opSoftGray);
+      .setColor(opWhite, opSoftGray);
 
       aCds.First;
       while not aCds.Eof do
       begin
         for idxFields := 0 to pred(aCds.Fields.Count) do
         begin
-          if (aCds.Fields[idx] is TCurrencyField) or
-             (aCds.Fields[idx] is TIntegerField)  or
-             (aCds.Fields[idx] is TFloatField)    or
-             (aCds.Fields[idx] is TNumericField)  then
+          if (aCds.Fields[idxFields] is TCurrencyField) or
+             (aCds.Fields[idxFields] is TIntegerField)  or
+             (aCds.Fields[idxFields] is TFloatField)    or
+             (aCds.Fields[idxFields] is TNumericField)  then
             lTypeVl := ftNumeric
            else
              lTypeVl := ftString;
 
-          SetValue(aCds.RecNo +1, FFields.arrFields[idxFields],aCds.Fields[idxFields].Value, lTypeVl)
+          SetValue(aCds.RecNo + 1, FFields.arrFields[idxFields], aCds.Fields[idxFields].Value, lTypeVl)
+          .setBorder([bAll], opBlack);
+        end;
+        aCds.Next;
+      end;
+  finally
+     aCds.EnableControls;
+  end;
+end;
+
+procedure TOpenOffice_calc.DataSetToSheet(const aCds: TDataSet);
+var
+	idx, idxFields : integer;
+    lTypeVl : TTypeValue;
+begin
+  aCds.DisableControls;
+  try
+    //Create header
+    for idx := 0 to pred(aCds.Fields.Count) do
+      SetValue(0, FFields.arrFields[idx], aCds.Fields[idx].DisplayName)
+      .setBold(true)
+      .setBorder([bAll], opBlack)
+      .changeFont('Liberation Sans',11)
+      .setColor(opWhite, opSoftGray);
+
+      aCds.First;
+      while not aCds.Eof do
+      begin
+        for idxFields := 0 to pred(aCds.Fields.Count) do
+        begin
+          if (aCds.Fields[idxFields] is TCurrencyField) or
+             (aCds.Fields[idxFields] is TIntegerField)  or
+             (aCds.Fields[idxFields] is TFloatField)    or
+             (aCds.Fields[idxFields] is TNumericField)  then
+            lTypeVl := ftNumeric
+           else
+             lTypeVl := ftString;
+
+          SetValue(aCds.RecNo + 1, FFields.arrFields[idxFields], aCds.Fields[idxFields].Value, lTypeVl)
           .setBorder([bAll], opBlack);
         end;
         aCds.Next;


### PR DESCRIPTION
- Corrected DataSetToSheet(const TClientDataSet) to use idxFields instead of idx ensuring proper type detection for each field.
- Added new overload DataSetToSheet(const TDataSet) to support generic datasets.
- Both implementations now correctly generate headers and apply formatting.